### PR TITLE
Set "owner" in build tasks to fix runaway accumulation in Problems listing.

### DIFF
--- a/res/sample-tasks.json
+++ b/res/sample-tasks.json
@@ -9,6 +9,7 @@
             "command": "make | ./build.bat | etc...",
             "problemMatcher": [
                 {
+		    "owner": "nesdev",
                     "pattern": [
                         {
                             "regexp": "^([^:]*):([0-9]+): ?([^:]*): ?(.*)$",
@@ -20,6 +21,7 @@
                     ]
                 },
                 {
+		    "owner": "nesdev",
                     "pattern": [
                         {
                             "regexp": "^([^:]*)\\(([0-9]+)\\): ?([^:]*): ?(.*)$",


### PR DESCRIPTION
VSCode's build tasks need the "owner" identifier to be set, otherwise entries added to Problems never go away on rebuild. See https://github.com/microsoft/vscode/issues/129341 for details.

Fixes issue #8 .